### PR TITLE
Persist avatar

### DIFF
--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -128,24 +128,17 @@ export class FabulaUltimaActor extends Actor {
 // 		return super.createEmbeddedDocuments(embeddedName, newData, options);
 // 	}
 //
-// 	/**
-// 	 * Override initializing a character to set default portraits.
-// 	 * @param {object} data object of an initialized character.
-// 	 * @param {object?} options optional object of options.
-// 	 */
-// 	static async create(data, options) {
-// 		if (!data.img) {
-// 			switch (data.type) {
-// 				case "party":
-// 					data.img = "systems/fabula-ultima/assets/fbl-sun.webp";
-// 					break;
-// 				default:
-// 					data.img = `systems/fabula-ultima/assets/fbl-${data.type}.webp`;
-// 					break;
-// 			}
-// 		}
-// 		super.create(data, options);
-// 	}
+//  /**
+//   * Override initializing a character to set default portraits.
+//   * @param {object} data object of an initialized character.
+//   * @param {object?} options optional object of options.
+//   */
+  static async create(data, options) {
+    if (!data.img) {
+      data.img = "https://www.toonsmag.com/wp-content/uploads/2023/04/Homer-Simpson-cartoon-538x1024.jpg";
+    }
+    super.create(data, options);
+  }
 //
 // 	toggleCondition(conditionName) {
 // 		const conditionValue = this.conditions[conditionName].value;

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -135,7 +135,14 @@ export class FabulaUltimaActor extends Actor {
 //   */
   static async create(data, options) {
     if (!data.img) {
-      data.img = "https://www.toonsmag.com/wp-content/uploads/2023/04/Homer-Simpson-cartoon-538x1024.jpg";
+      switch (data.type) {
+        case "party":
+          data.img = "systems/fabula-ultima/assets/fbl-sun.webp";
+          break;
+        default:
+          data.img = `systems/fabula-ultima/assets/fbl-${data.type}.webp`;
+          break;
+        }
     }
     super.create(data, options);
   }

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -142,7 +142,7 @@ export class FabulaUltimaActor extends Actor {
         default:
           data.img = `systems/fabula-ultima/assets/fbl-${data.type}.webp`;
           break;
-        }
+      }
     }
     super.create(data, options);
   }

--- a/src/actor/character/sheets-tabs/main-tab.hbs
+++ b/src/actor/character/sheets-tabs/main-tab.hbs
@@ -105,8 +105,7 @@
   </div>
 
   <section class="right-sidebar">
-    <img class="profile-img" src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcROo-89Ylv98984xHOU5ROn8j0fgF346XHoWbbMK-SUV36IuVByqSnNZn0fk3NW1WY3Yb8&usqp=CAU" title="{{name}}" />
-    {{!-- data-edit="img" --}}
+    <img class="profile-img" src="{{this.actor.img}}" data-edit="img" />
   </section>
 
   <footer class="footer">


### PR DESCRIPTION
Comment in actor-document create method to set a default. Unlike in forbidden lands, which simply uses `img` in their template, we needed to use `this.actor.img`, presumably because our template is in a different scope. Also, switched to the homer image because the original errors for not having a file extension.