### PR TITLE
Add bump command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.0.3](https://github.com/AllPurposeName/fabula-ultima-foundry-vtt/compare/v1.0.2...v1.0.3) (2023-11-9)
+
+#### Bug Fixes
+
+* add public attributes

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@
 * yarn link-project
 * Close and reopen Foundry VTT. Fabula Ultima should appear in your Game
   Systems.
+
+### Releasing
+* Run `yarn bump -r {step}`, where step is one of: [major, premajor, minor, preminor, patch, prepatch, prerelease]
+* Fill out release notes in CHANGELOG.md
+* Run `yarn release`

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"dev:watch": "cross-env NODE_ENV=development gulp watch",
 		"build": "cross-env NODE_ENV=production gulp build",
 		"link-project": "gulp link",
+		"bump": "gulp bump",
 		"release": "gulp release",
 		"unlink-project": "rm $(grep -o 'dataPath\": \".*' foundryconfig.json | awk '{print $2}' | tr -d '\"')/systems/fabula-ultima && rm -rf dist"
 	},
@@ -39,12 +40,13 @@
 		"@typhonjs-fvtt/eslint-config-foundry.js": "0.8.0",
 		"chalk": "^5",
 		"cross-env": "^7",
-		"esbuild": "^19",
+		"esbuild": "^0.19",
 		"esbuild-sass-plugin": "^2.10",
 		"execa": "^7",
 		"fs-extra": "^11",
 		"fs-extra-plus": "^0.6.0",
 		"gulp": "^4",
-		"prettier": "2.8.8"
+		"prettier": "2.8.8",
+		"yargs": "^17.7.2"
 	}
 }


### PR DESCRIPTION
I don't think this fully fixes our release command - at the very least, since I don't have permissions to push to main, I couldn't run `yarn release` on main, and I wouldn't want to tag a non-main branch. But this does get `yarn bump` working nicely, updating all the correct versions as well as the download url, and generating a changelog section.

Also pins esbuild to a version that exists (0.19.5 is current).

We may want to look at the example in
https://gulpjs.com/docs/en/recipes/automate-releases/ for a more robust release process.