### PR TITLE
Add initial styling for tooltips

### DIFF
--- a/src/actor/character/sheets-tabs/main-tab.hbs
+++ b/src/actor/character/sheets-tabs/main-tab.hbs
@@ -120,7 +120,11 @@
       {{> "systems/fabula-ultima/templates/actor/character/parts/bonds.hbs" }}
     </div>
     <div class="fabula-points">
-      <h3 title="{{localize "FABULA_POINTS.GAIN"}}">{{localize "BIO.FABULA_POINTS"}}<i class="fas fa-meteor"></i> </h3>
+      <h3 class="tooltip-right">
+        {{localize "BIO.FABULA_POINTS"}}
+        <i class="fas fa-meteor"></i>
+        <span class="tooltip-text">{{localize "FABULA_POINTS.GAIN"}}</span>
+      </h3>
       <input id="number-input" type="number" name="system.bio.fabulaPoints.value" value="{{this.actor.bio.fabulaPoints.value}}" />
       <div class="fabula-li">
         <i class="fas fa-file-pen"></i>
@@ -141,7 +145,11 @@
     </div>
 
     <div class="inventory-points">
-      <h3 title="{{localize "INVENTORY.GAIN"}}">{{localize "BIO.INVENTORY_POINTS"}}<i class="fas fa-sack-xmark"></i> </h3>
+      <h3 class="tooltip-left">
+        {{localize "BIO.INVENTORY_POINTS"}}
+        <i class="fas fa-sack-xmark"></i>
+        <span class="tooltip-text">{{localize "INVENTORY.GAIN"}}</span>
+      </h3>
       <div class="inventory-points-fields">
         <p class="inventory-points-header">{{localize "BIO.IP"}}</p>
         <input id="number-input" type="number" name="system.baseAttribute.baseInventoryPoints.value" value="{{this.actor.attributes.baseInventoryPoints.value}}" />

--- a/src/actor/character/styles/_character.scss
+++ b/src/actor/character/styles/_character.scss
@@ -47,3 +47,81 @@
     cursor: pointer;
   }
 }
+
+.tooltip-top, .tooltip-bottom, .tooltip-right, .tooltip-left {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip-top .tooltip-text {
+  bottom: 100%;
+  left: 50%;
+}
+
+.tooltip-bottom .tooltip-text {
+  top: 100%;
+  left: 50%;
+}
+
+.tooltip-right .tooltip-text {
+  top: -5px;
+  left: 105%;
+}
+
+.tooltip-left .tooltip-text {
+  top: -5px;
+  right: 105%;
+}
+
+:is(.tooltip-top, .tooltip-bottom, .tooltip-right, .tooltip-left) .tooltip-text {
+  visibility: hidden;
+  background-color: black;
+  color: #fff;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+  width: max-content;
+  max-width: 200px;
+}
+
+:is(.tooltip-top, .tooltip-bottom, .tooltip-right, .tooltip-left):hover .tooltip-text {
+  visibility: visible;
+  font-size: 0.8em;
+}
+
+:is(.tooltip-top, .tooltip-bottom, .tooltip-right, .tooltip-left) .tooltip-text::after {
+  content: " ";
+  position: absolute;
+  border-width: 5px;
+  border-style: solid;
+}
+
+.tooltip-top .tooltip-text::after {
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-color: black transparent transparent transparent;
+}
+
+.tooltip-bottom .tooltip-text::after {
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-color: transparent transparent black transparent;
+}
+
+.tooltip-right .tooltip-text::after {
+  top: 50%;
+  right: 100%;
+  margin-top: -5px;
+  border-color: transparent black transparent transparent;
+}
+
+.tooltip-left .tooltip-text::after {
+  top: 50%;
+  left: 100%;
+  margin-top: -5px;
+  border-color: transparent transparent transparent black;
+}

--- a/src/actor/character/styles/_character.scss
+++ b/src/actor/character/styles/_character.scss
@@ -78,7 +78,7 @@
   visibility: hidden;
   background-color: black;
   color: #fff;
-  padding: 5px 0;
+  padding: 5px;
   border-radius: 6px;
   position: absolute;
   z-index: 1;

--- a/src/actor/character/templates/parts/bonds.hbs
+++ b/src/actor/character/templates/parts/bonds.hbs
@@ -6,7 +6,7 @@
     <div class="item-name">{{localize "BOND.RELIANCE"}}</div>
     <div class="item-name">{{localize "BOND.DISPOSITION"}}</div>
     <div class="item-controls">
-      <a class="item-control item-create" title="Create item" data-type="bond"><i class="fas fa-plus"></i> {{localize "BOND.ADD"}}</a>
+      <a class="item-control item-create" data-type="bond"><i class="fas fa-plus"></i> {{localize "BOND.ADD"}}</a>
     </div>
   </li>
   {{#each bonds as |bond id|}}
@@ -31,7 +31,10 @@
       </div>
 
       <div class="item-controls">
-        <a class="item-control item-delete" title="{{localize 'BOND.DELETE'}}"><i class="fas fa-trash"></i></a>
+        <a class="item-control item-delete tooltip-bottom">
+          <i class="fas fa-trash"></i>
+          <span class="tooltip-text">{{localize 'BOND.DELETE'}}</span>
+        </a>
       </div>
     </li>
   {{/each}}


### PR DESCRIPTION
Tooltips can now be easily added without looking terrible. This work is largely based on https://www.w3schools.com/css/css_tooltip.asp, with a huge assist to simplify the width handling from
https://stackoverflow.com/a/62853552/11616870.

Notably, the 'Create Item' title was copied from somewhere, and was hover text over 'Add Bond', which was much more descriptive anyway, so I deleted that one. It was also untranslated to boot.

This is far from perfect (specifically, the arrow doesn't seem to point exactly where I'd expect), and I welcome any changes on this PR, but it does look much better, and I'd be happy to never see css again before I die.

![image](https://github.com/AllPurposeName/fabula-ultima-foundry-vtt/assets/1421705/09038a2b-d0f7-441f-8761-de23ac1115cd)
![image](https://github.com/AllPurposeName/fabula-ultima-foundry-vtt/assets/1421705/c965d428-3b2f-4ed6-8845-7b6547255f4c)
![image](https://github.com/AllPurposeName/fabula-ultima-foundry-vtt/assets/1421705/171dad3b-f44f-479d-9c84-1f3373930d96)
