### PR TITLE
Replace grid-template-areas with grid-column

### DIFF
--- a/src/actor/character/sheets-tabs/main-tab.hbs
+++ b/src/actor/character/sheets-tabs/main-tab.hbs
@@ -1,5 +1,5 @@
 <div class="main-tab">
-  <div class="left-content">
+  <div class="left-content double-wide">
     {{> "systems/fabula-ultima/templates/actor/character/parts/initiative.hbs" }}
     {{> "systems/fabula-ultima/templates/actor/character/parts/pronouns.hbs" }}
     {{> "systems/fabula-ultima/templates/actor/parts/defense.hbs" }}
@@ -14,7 +14,7 @@
     {{> "systems/fabula-ultima/templates/actor/parts/profile_images.hbs" }}
   </section>
 
-  <footer class="footer">
+  <footer class="footer triple-wide">
     {{> "systems/fabula-ultima/templates/actor/character/parts/bonds.hbs" }}
     {{> "systems/fabula-ultima/templates/actor/character/parts/fabula_points.hbs" }}
     {{> "systems/fabula-ultima/templates/actor/character/parts/inventory_points.hbs" }}

--- a/src/actor/character/styles/character/_main-tab.scss
+++ b/src/actor/character/styles/character/_main-tab.scss
@@ -1,20 +1,10 @@
-.left-content > .initiative-modifier {
-  grid-area:initiative-modifier;
-}
-
-.left-content > .pronouns {
-  grid-area:pronouns;
-}
-
 .left-content > .defense {
-  grid-area:defense;
   position: relative;
   bottom: 35px;
   margin-top: 34px;
 }
 
 .left-content > .magic-defense {
-  grid-area:magic-defense;
   position: relative;
   bottom: 35px;
   margin-top: 34px;
@@ -23,34 +13,6 @@
 .left-content > .points {
   position: relative;
   bottom: 25px;
-}
-
-.left-content > .hit-points {
-  grid-area:hit-points;
-}
-
-.left-content > .mind-points {
-  grid-area:mind-points;
-}
-
-.left-content > .affinities {
-  grid-area:affinities;
-}
-
-.left-content > .attacks {
-  grid-area:attacks;
-}
-
-.left-content > .spells {
-  grid-area:spells;
-}
-
-.left-content > .other-actions {
-  grid-area:other-actions;
-}
-
-.left-content > .special-rules {
-  grid-area:special-rules;
 }
 
 .traits-with-answer {
@@ -108,7 +70,6 @@
 }
 
 .main-tab > .footer {
-  grid-area:footer;
   display: grid;
   grid-gap: 20px;
   grid-template-columns: repeat(5, 1fr);

--- a/src/actor/monster/sheets-tabs/main-tab.hbs
+++ b/src/actor/monster/sheets-tabs/main-tab.hbs
@@ -1,5 +1,5 @@
 <div class="main-tab">
-  <div class="left-content">
+  <div class="left-content double-wide">
     <section id="monsterPointsAndDefences">
       {{> "systems/fabula-ultima/templates/actor/parts/hit_points.hbs" }}
       {{> "systems/fabula-ultima/templates/actor/parts/mind_points.hbs" }}

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -1,4 +1,4 @@
-<section class='affinities' id="monsterAffinities">
+<section class='affinities double-wide' id="monsterAffinities">
   <h3>{{localize "BIO.AFFINITIES"}} <i class="fas fa-sparkles"></i></h3>
   <h4>
     {{localize "BIO.VULNERABILE"}}

--- a/src/actor/monster/templates/parts/attacks.hbs
+++ b/src/actor/monster/templates/parts/attacks.hbs
@@ -1,4 +1,4 @@
-<section class='attacks monster-textareas' id="monsterAttacks">
+<section class='attacks monster-textareas double-wide' id="monsterAttacks">
   <h3>{{localize "BIO.ATTACKS"}}<i class="fas fa-swords"></i> </h3>
   <textarea name="system.bio.attacks.value">{{this.actor.bio.attacks.value}}</textarea>
 </section>

--- a/src/actor/monster/templates/parts/special_rules.hbs
+++ b/src/actor/monster/templates/parts/special_rules.hbs
@@ -1,4 +1,4 @@
-<section class='special-rules monster-textareas' id="monsterSpecialRules">
+<section class='special-rules monster-textareas double-wide' id="monsterSpecialRules">
   <h3>{{localize "BIO.SPECIAL_RULES"}}</h3>
   <textarea name="system.bio.special-rules.value">{{this.actor.bio.special-rules.value}}</textarea>
 </section>

--- a/src/actor/monster/templates/parts/spells.hbs
+++ b/src/actor/monster/templates/parts/spells.hbs
@@ -1,4 +1,4 @@
-<section class='spells monster-textareas' id="monsterSpells">
+<section class='spells monster-textareas double-wide' id="monsterSpells">
   <h3>{{localize "BIO.SPELLS"}}<i class="fas fa-wand-magic-sparkles"></i> </h3>
   <textarea name="system.bio.spells.value">{{this.actor.bio.spells.value}}</textarea>
 </section>

--- a/src/actor/monster/templates/parts/traits.hbs
+++ b/src/actor/monster/templates/parts/traits.hbs
@@ -1,4 +1,4 @@
-<section class="traits-section">
+<section class="traits-section double-wide">
   <h3>{{localize "BIO.TRAITS"}}<i class="fas fa-fingerprint"></i> </h3>
   <div class="traits">
     <div class="trait-with-answer">

--- a/src/actor/styles/actor/_main-tab.scss
+++ b/src/actor/styles/actor/_main-tab.scss
@@ -20,9 +20,6 @@
   background: white;
   display:grid;
   grid-template-columns:repeat(3, 1fr);
-  grid-template-areas:
-  'left-content left-content right-sidebar'
-  'footer footer footer';
 }
 
 .main-tab > * {
@@ -34,22 +31,18 @@
   font-weight: bold;
 }
 
+.double-wide {
+  grid-column: span 2;
+}
+
+.triple-wide {
+  grid-column: span 3;
+}
+
 .main-tab > .left-content {
-  grid-area:left-content;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-auto-rows: minmax(1fr, auto);
-  grid-template-areas:
-    'initiative-modifier pronouns'
-    'defense magic-defense'
-    'hit-points mind-points'
-    'affinities .'
-    'attributes-and-status-effects attributes-and-status-effects'
-    'traits traits'
-    'attacks .'
-    'spells .'
-    'other-actions .'
-    'special-rules .';
 }
 
 .hit-points > h4 > input {
@@ -69,7 +62,6 @@
 }
 
 .left-content > .attributes-and-status-effects {
-  grid-area:attributes-and-status-effects;
   border-bottom: 1px solid grey;
   border-left: 1px solid grey;
   border-top: 1px solid grey;
@@ -188,8 +180,4 @@
 
 .left-content > .traits-section {
   grid-area:traits;
-}
-
-.main-tab > .right-sidebar {
-  grid-area:right-sidebar;
 }

--- a/src/actor/templates/parts/attributes_and_status_effects.hbs
+++ b/src/actor/templates/parts/attributes_and_status_effects.hbs
@@ -1,4 +1,4 @@
-<section class="attributes-and-status-effects">
+<section class="attributes-and-status-effects double-wide">
   <h3 class="header">{{localize "BIO.ATTRIBUTES_AND_STATUS_EFFECTS"}}<i class="fas fa-hand-fist"></i></h3>
   <div class="attribute-stats dexterity">
     <p class="attribute">{{localize "ATTRIBUTE.DEXTERITY"}}</p>


### PR DESCRIPTION
Open to opinions, but personally I found the grid-template-areas really confusing, which isn't a reason not to use them, but I do think it's much simpler to simply allow the fields to be displayed in the order they're defined and mark the ones that are multiple columns.

This unfortunately doesn't work with attributes_and_status_effects and the footer because there are blank spaces. Maybe there's another solution for those that isn't defining an empty div?

What do y'all think? And is there a better name than double-/triple-wide?