### PR TITLE
Update monster affinities

### DIFF
--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -1,6 +1,27 @@
 import localize from "@utils/localize-string.js";
 
 export class FabulaUltimaActor extends Actor {
+  constructor(data, options) {
+    super(data, options);
+
+    // Initialize affinities if not already defined
+    if (!this.data.data.affinities) {
+      console.error('this.data.data.affinities is undefined. Initializing...');
+
+      this.update({
+        'data.affinities': {
+          physical: {
+            class: 'affinity-inactive',
+            value: '-', // Set the initial value or appropriate type
+          },
+          // ... other affinities
+        }
+      });
+
+      console.log('Initialized affinities:', this.data.data.affinities);
+    }
+  }
+
   get actorProperties() {
     return this.system;
   }

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -10,7 +10,7 @@ export class FabulaUltimaActor extends Actor {
         'affinities': {
           physical: {
             class: 'affinity-inactive',
-            value: '-', // Set the initial value or appropriate type
+            value: '-'
           },
           // ... other affinities
         }

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -5,11 +5,9 @@ export class FabulaUltimaActor extends Actor {
     super(data, options);
 
     // Initialize affinities if not already defined
-    if (!this.data.data.affinities) {
-      console.error('this.data.data.affinities is undefined. Initializing...');
-
+    if (!this.affinities) {
       this.update({
-        'data.affinities': {
+        'affinities': {
           physical: {
             class: 'affinity-inactive',
             value: '-', // Set the initial value or appropriate type
@@ -17,8 +15,6 @@ export class FabulaUltimaActor extends Actor {
           // ... other affinities
         }
       });
-
-      console.log('Initialized affinities:', this.data.data.affinities);
     }
   }
 

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -5,14 +5,45 @@ export class FabulaUltimaActor extends Actor {
     super(data, options);
 
     // Initialize affinities if not already defined
-    if (!this.affinities) {
+    if (!this.system.affinities) {
       this.update({
-        'affinities': {
-          physical: {
+        'data.affinities': {
+          'physical': {
             class: 'affinity-inactive',
             value: '-'
           },
-          // ... other affinities
+          'air': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'bolt': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'dark': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'earth': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'fire': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'ice': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'light': {
+            class: 'affinity-inactive',
+            value: '-'
+          },
+          'poison': {
+            class: 'affinity-inactive',
+            value: '-'
+          }
         }
       });
     }

--- a/src/actor/monster/monster-sheet.js
+++ b/src/actor/monster/monster-sheet.js
@@ -47,11 +47,24 @@ export class FabulaUltimaMonsterSheet extends FabulaUltimaActorSheet {
         }
       })
 
+      const AFFINITY_MAP = {
+        'affinity-inactive': '-',
+        'affinity-vulnerable': 'VU',
+        'affinity-resistant': 'RS',
+        'affinity-immune': 'IM',
+        'affinity-absorbs': 'AB'
+      }
+
+      const affinityKeys = Object.keys(AFFINITY_MAP)
+
       html.find('.affinity-boxes').on('click', '.affinity-box', ev => {
         const target = ev.currentTarget;
-        console.log(target);
-        target.classList.remove('inactive-affinity');
-        // Additional logic here
+        const currentAffinityIndex = affinityKeys.indexOf(target.classList[2]);
+        const nextAffinityIndex = (currentAffinityIndex + 1) % affinityKeys.length;
+        target.classList.remove(affinityKeys[currentAffinityIndex]);
+        target.classList.add(affinityKeys[nextAffinityIndex]);
+        this.actor.affinities.physical.value = AFFINITY_MAP[affinityKeys[nextAffinityIndex]];
+        this.render();
       })
     }
 }

--- a/src/actor/monster/monster-sheet.js
+++ b/src/actor/monster/monster-sheet.js
@@ -64,9 +64,10 @@ export class FabulaUltimaMonsterSheet extends FabulaUltimaActorSheet {
       target.classList.remove(affinityKeys[currentAffinityIndex]);
       target.classList.add(affinityKeys[nextAffinityIndex]);
 
+      const thisAffinity = target.classList[1].split('-')[1]
       await this.actor.update({
-        'system.affinities.physical.class': affinityKeys[nextAffinityIndex],
-        'system.affinities.physical.value': AFFINITY_MAP[affinityKeys[nextAffinityIndex]],
+        [`system.affinities.${thisAffinity}.class`]: affinityKeys[nextAffinityIndex],
+        [`system.affinities.${thisAffinity}.value`]: AFFINITY_MAP[affinityKeys[nextAffinityIndex]],
       });
     })
   }

--- a/src/actor/monster/monster-sheet.js
+++ b/src/actor/monster/monster-sheet.js
@@ -46,5 +46,12 @@ export class FabulaUltimaMonsterSheet extends FabulaUltimaActorSheet {
           ev.target.style.height = ev.target.scrollHeight + 'px';
         }
       })
+
+      html.find('.affinity-boxes').on('click', '.affinity-box', ev => {
+        const target = ev.currentTarget;
+        console.log(target);
+        target.classList.remove('inactive-affinity');
+        // Additional logic here
+      })
     }
 }

--- a/src/actor/monster/monster-sheet.js
+++ b/src/actor/monster/monster-sheet.js
@@ -31,40 +31,43 @@ export class FabulaUltimaMonsterSheet extends FabulaUltimaActorSheet {
   }
 
     /** override **/
-    activateListeners(html) {
-      super.activateListeners(html);
+  activateListeners(html) {
+    super.activateListeners(html);
 
-      html.find('.monster-textareas textarea').each((i, el) => {
-        el.style.height = 'auto';
-        el.style.height = `${el.scrollHeight}px`
-      });
+    html.find('.monster-textareas textarea').each((i, el) => {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`
+    });
 
-      html.find('.monster-textareas').on('input', (ev) => {
-        ev.preventDefault();
-        if (ev.target.tagName.toLowerCase() === 'textarea') {
-          ev.target.style.height = 'auto';
-          ev.target.style.height = ev.target.scrollHeight + 'px';
-        }
-      })
-
-      const AFFINITY_MAP = {
-        'affinity-inactive': '-',
-        'affinity-vulnerable': 'VU',
-        'affinity-resistant': 'RS',
-        'affinity-immune': 'IM',
-        'affinity-absorbs': 'AB'
+    html.find('.monster-textareas').on('input', (ev) => {
+      ev.preventDefault();
+      if (ev.target.tagName.toLowerCase() === 'textarea') {
+        ev.target.style.height = 'auto';
+        ev.target.style.height = ev.target.scrollHeight + 'px';
       }
+    })
 
-      const affinityKeys = Object.keys(AFFINITY_MAP)
-
-      html.find('.affinity-boxes').on('click', '.affinity-box', ev => {
-        const target = ev.currentTarget;
-        const currentAffinityIndex = affinityKeys.indexOf(target.classList[2]);
-        const nextAffinityIndex = (currentAffinityIndex + 1) % affinityKeys.length;
-        target.classList.remove(affinityKeys[currentAffinityIndex]);
-        target.classList.add(affinityKeys[nextAffinityIndex]);
-        this.actor.affinities.physical.value = AFFINITY_MAP[affinityKeys[nextAffinityIndex]];
-        this.render();
-      })
+    const AFFINITY_MAP = {
+      'affinity-inactive': '-',
+      'affinity-vulnerable': 'VU',
+      'affinity-resistant': 'RS',
+      'affinity-immune': 'IM',
+      'affinity-absorbs': 'AB'
     }
+
+    const affinityKeys = Object.keys(AFFINITY_MAP)
+
+    html.find('.affinity-boxes').on('click', '.affinity-box', async ev => {
+      const target = ev.currentTarget;
+      const currentAffinityIndex = affinityKeys.indexOf(target.classList[2]);
+      const nextAffinityIndex = (currentAffinityIndex + 1) % affinityKeys.length;
+      target.classList.remove(affinityKeys[currentAffinityIndex]);
+      target.classList.add(affinityKeys[nextAffinityIndex]);
+
+      await this.actor.update({
+        'system.affinities.physical.class': affinityKeys[nextAffinityIndex],
+        'system.affinities.physical.value': AFFINITY_MAP[affinityKeys[nextAffinityIndex]],
+      });
+    })
+  }
 }

--- a/src/actor/monster/sheets-tabs/main-tab.hbs
+++ b/src/actor/monster/sheets-tabs/main-tab.hbs
@@ -1,6 +1,6 @@
 <div class="main-tab">
   <div class="left-content">
-    <section id="monsterPointsAndDefences">
+    <section class="monster-points-and-defences">
       {{> "systems/fabula-ultima/templates/actor/parts/hit_points.hbs" }}
       {{> "systems/fabula-ultima/templates/actor/parts/mind_points.hbs" }}
       {{> "systems/fabula-ultima/templates/actor/parts/defense.hbs" }}

--- a/src/actor/monster/styles/monster/_main-tab.scss
+++ b/src/actor/monster/styles/monster/_main-tab.scss
@@ -51,8 +51,14 @@
   width: 50px;
   display: flex;
   align-items: center;
+  justify-content: space-around;
   border: #6d6d6d 1px solid;
   cursor: pointer;
+}
+
+.affinity-box > span {
+  transform: scaleY(2);
+  font-family: fangsong;
 }
 
 .affinity-inactive {

--- a/src/actor/monster/styles/monster/_main-tab.scss
+++ b/src/actor/monster/styles/monster/_main-tab.scss
@@ -1,8 +1,8 @@
-#typicalTraits {
+.typical-traits {
   width: calc(100% - 87px);
 }
 
-#monsterExperienceFields {
+.monster-experience-fields {
   flex-direction: row;
 }
 
@@ -16,11 +16,11 @@
   }
 }
 
-#monsterLevel {
+.monster-level {
   z-index: 1;
 }
 
-#monsterPointsAndDefences {
+.monster-points-and-defences {
   display: flex;
   width: 400px;
   flex-wrap: wrap;
@@ -32,15 +32,22 @@
   }
 }
 
-#monsterAffinities {
+.monster-affinities {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
   margin-bottom: 20px;
   & > h3 {
     width: 400px;
   }
-  & > h4 > input {
-    width: 150px;
-  }
+}
+
+.affinity-boxes {
+  width: 400px;
+  display: flex;
+}
+
+.affinity-box {
+  height: 40px;
+  width: 50px;
+  border: black 1px solid;
 }

--- a/src/actor/monster/styles/monster/_main-tab.scss
+++ b/src/actor/monster/styles/monster/_main-tab.scss
@@ -55,6 +55,22 @@
   cursor: pointer;
 }
 
-.inactive-affinity {
+.affinity-inactive {
   color: lightgray;
+}
+
+.affinity-vulnerable {
+  color: red;
+}
+
+.affinity-resistant {
+  color: blue;
+}
+
+.affinity-immune {
+  color: gold;
+}
+
+.affinity-absorbs {
+  color: green;
 }

--- a/src/actor/monster/styles/monster/_main-tab.scss
+++ b/src/actor/monster/styles/monster/_main-tab.scss
@@ -3,7 +3,7 @@
 }
 
 .monster-experience-fields {
-  flex-direction: row;
+  flex-direction: row !important;
 }
 
 .monster-main-fields {
@@ -49,5 +49,12 @@
 .affinity-box {
   height: 40px;
   width: 50px;
-  border: black 1px solid;
+  display: flex;
+  align-items: center;
+  border: #6d6d6d 1px solid;
+  cursor: pointer;
+}
+
+.inactive-affinity {
+  color: lightgray;
 }

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -5,13 +5,37 @@
       <i class="fa-regular fa-sword"></i>
       <span>{{this.actor.system.affinities.physical.value}}</span>
     </div>
-    <div class="affinity-box affinity-air affinity-inactive"></div>
-    <div class="affinity-box affinity-bolt affinity-inactive"></div>
-    <div class="affinity-box affinity-dark affinity-inactive"></div>
-    <div class="affinity-box affinity-earth affinity-inactive"></div>
-    <div class="affinity-box affinity-fire affinity-inactive"></div>
-    <div class="affinity-box affinity-ice affinity-inactive"></div>
-    <div class="affinity-box affinity-light affinity-inactive"></div>
-    <div class="affinity-box affinity-poison affinity-inactive"></div>
+    <div class="affinity-box affinity-air {{this.actor.system.affinities.air.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.air.value}}</span>
+    </div>
+    <div class="affinity-box affinity-bolt {{this.actor.system.affinities.bolt.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.bolt.value}}</span>
+    </div>
+    <div class="affinity-box affinity-dark {{this.actor.system.affinities.dark.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.dark.value}}</span>
+    </div>
+    <div class="affinity-box affinity-earth {{this.actor.system.affinities.earth.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.earth.value}}</span>
+    </div>
+    <div class="affinity-box affinity-fire {{this.actor.system.affinities.fire.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.fire.value}}</span>
+    </div>
+    <div class="affinity-box affinity-ice {{this.actor.system.affinities.ice.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.ice.value}}</span>
+    </div>
+    <div class="affinity-box affinity-light {{this.actor.system.affinities.light.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.light.value}}</span>
+    </div>
+    <div class="affinity-box affinity-poison {{this.actor.system.affinities.poison.class}}">
+      <i class="fa-regular fa-sword"></i>
+      <span>{{this.actor.system.affinities.poison.value}}</span>
+    </div>
   </div>
 </section>

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -3,7 +3,7 @@
   <div class="affinity-boxes">
     <div class="affinity-box affinity-physical {{this.actor.system.affinities.physical.class}}">
       <i class="fa-regular fa-sword"></i>
-      {{this.actor.system.affinities.physical.value}}
+      <span>{{this.actor.system.affinities.physical.value}}</span>
     </div>
     <div class="affinity-box affinity-air affinity-inactive"></div>
     <div class="affinity-box affinity-bolt affinity-inactive"></div>

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -1,16 +1,17 @@
 <section class="affinities monster-affinities">
   <h3>{{localize "BIO.AFFINITIES"}} <i class="fas fa-sparkles"></i></h3>
   <div class="affinity-boxes">
-    <div class="affinity-box affinity-physical inactive-affinity">
+    <div class="affinity-box affinity-physical affinity-inactive">
       <i class="fa-regular fa-sword"></i>
+      {{this.actor.affinities.physical.value}}
     </div>
-    <div class="affinity-box affinity-air inactive-affinity"></div>
-    <div class="affinity-box affinity-bolt inactive-affinity"></div>
-    <div class="affinity-box affinity-dark inactive-affinity"></div>
-    <div class="affinity-box affinity-earth inactive-affinity"></div>
-    <div class="affinity-box affinity-fire inactive-affinity"></div>
-    <div class="affinity-box affinity-ice inactive-affinity"></div>
-    <div class="affinity-box affinity-light inactive-affinity"></div>
-    <div class="affinity-box affinity-poison inactive-affinity"></div>
+    <div class="affinity-box affinity-air affinity-inactive"></div>
+    <div class="affinity-box affinity-bolt affinity-inactive"></div>
+    <div class="affinity-box affinity-dark affinity-inactive"></div>
+    <div class="affinity-box affinity-earth affinity-inactive"></div>
+    <div class="affinity-box affinity-fire affinity-inactive"></div>
+    <div class="affinity-box affinity-ice affinity-inactive"></div>
+    <div class="affinity-box affinity-light affinity-inactive"></div>
+    <div class="affinity-box affinity-poison affinity-inactive"></div>
   </div>
 </section>

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -1,9 +1,9 @@
 <section class="affinities monster-affinities">
   <h3>{{localize "BIO.AFFINITIES"}} <i class="fas fa-sparkles"></i></h3>
   <div class="affinity-boxes">
-    <div class="affinity-box affinity-physical affinity-inactive">
+    <div class="affinity-box affinity-physical {{this.actor.system.affinities.physical.class}}">
       <i class="fa-regular fa-sword"></i>
-      {{this.actor.affinities.physical.value}}
+      {{this.actor.system.affinities.physical.value}}
     </div>
     <div class="affinity-box affinity-air affinity-inactive"></div>
     <div class="affinity-box affinity-bolt affinity-inactive"></div>

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -6,35 +6,35 @@
       <span>{{this.actor.system.affinities.physical.value}}</span>
     </div>
     <div class="affinity-box affinity-air {{this.actor.system.affinities.air.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-light fa-wind"></i>
       <span>{{this.actor.system.affinities.air.value}}</span>
     </div>
     <div class="affinity-box affinity-bolt {{this.actor.system.affinities.bolt.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-light fa-bolt"></i>
       <span>{{this.actor.system.affinities.bolt.value}}</span>
     </div>
     <div class="affinity-box affinity-dark {{this.actor.system.affinities.dark.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-solid fa-moon"></i>
       <span>{{this.actor.system.affinities.dark.value}}</span>
     </div>
     <div class="affinity-box affinity-earth {{this.actor.system.affinities.earth.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-solid fa-leaf"></i>
       <span>{{this.actor.system.affinities.earth.value}}</span>
     </div>
     <div class="affinity-box affinity-fire {{this.actor.system.affinities.fire.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-regular fa-fire"></i>
       <span>{{this.actor.system.affinities.fire.value}}</span>
     </div>
     <div class="affinity-box affinity-ice {{this.actor.system.affinities.ice.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-regular fa-snowflake"></i>
       <span>{{this.actor.system.affinities.ice.value}}</span>
     </div>
     <div class="affinity-box affinity-light {{this.actor.system.affinities.light.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-regular fa-sparkles"></i>
       <span>{{this.actor.system.affinities.light.value}}</span>
     </div>
     <div class="affinity-box affinity-poison {{this.actor.system.affinities.poison.class}}">
-      <i class="fa-regular fa-sword"></i>
+      <i class="fa-regular fa-flask-round-poison"></i>
       <span>{{this.actor.system.affinities.poison.value}}</span>
     </div>
   </div>

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -1,14 +1,16 @@
 <section class="affinities monster-affinities">
   <h3>{{localize "BIO.AFFINITIES"}} <i class="fas fa-sparkles"></i></h3>
   <div class="affinity-boxes">
-    <div class="affinity-box affinity-physical"></div>
-    <div class="affinity-box affinity-air"></div>
-    <div class="affinity-box affinity-bolt"></div>
-    <div class="affinity-box affinity-dark"></div>
-    <div class="affinity-box affinity-earth"></div>
-    <div class="affinity-box affinity-fire"></div>
-    <div class="affinity-box affinity-ice"></div>
-    <div class="affinity-box affinity-light"></div>
-    <div class="affinity-box affinity-poison"></div>
+    <div class="affinity-box affinity-physical inactive-affinity">
+      <i class="fa-regular fa-sword"></i>
+    </div>
+    <div class="affinity-box affinity-air inactive-affinity"></div>
+    <div class="affinity-box affinity-bolt inactive-affinity"></div>
+    <div class="affinity-box affinity-dark inactive-affinity"></div>
+    <div class="affinity-box affinity-earth inactive-affinity"></div>
+    <div class="affinity-box affinity-fire inactive-affinity"></div>
+    <div class="affinity-box affinity-ice inactive-affinity"></div>
+    <div class="affinity-box affinity-light inactive-affinity"></div>
+    <div class="affinity-box affinity-poison inactive-affinity"></div>
   </div>
 </section>

--- a/src/actor/monster/templates/parts/affinities.hbs
+++ b/src/actor/monster/templates/parts/affinities.hbs
@@ -1,19 +1,14 @@
-<section class='affinities' id="monsterAffinities">
+<section class="affinities monster-affinities">
   <h3>{{localize "BIO.AFFINITIES"}} <i class="fas fa-sparkles"></i></h3>
-  <h4>
-    {{localize "BIO.VULNERABILE"}}
-    <input name="system.bio.vulnerabilities.value" type="text" value="{{this.actor.bio.vulnerabilities.value}}" />
-  </h4>
-  <h4>
-    {{localize "BIO.RESISTANT"}}
-    <input name="system.bio.resistances.value" type="text" value="{{this.actor.bio.resistances.value}}" />
-  </h4>
-  <h4>
-    {{localize "BIO.IMMUNE"}}
-    <input name="system.bio.immunities.value" type="text" value="{{this.actor.bio.immunities.value}}" />
-  </h4>
-  <h4>
-    {{localize "BIO.ABSORBS"}}
-    <input name="system.bio.absorbs.value" type="text" value="{{this.actor.bio.absorbs.value}}" />
-  </h4>
+  <div class="affinity-boxes">
+    <div class="affinity-box affinity-physical"></div>
+    <div class="affinity-box affinity-air"></div>
+    <div class="affinity-box affinity-bolt"></div>
+    <div class="affinity-box affinity-dark"></div>
+    <div class="affinity-box affinity-earth"></div>
+    <div class="affinity-box affinity-fire"></div>
+    <div class="affinity-box affinity-ice"></div>
+    <div class="affinity-box affinity-light"></div>
+    <div class="affinity-box affinity-poison"></div>
+  </div>
 </section>

--- a/src/actor/monster/templates/parts/experience.hbs
+++ b/src/actor/monster/templates/parts/experience.hbs
@@ -1,6 +1,6 @@
 <section class="experience">
-  <div id='monsterExperienceFields' class="experience-fields" >
-    <div><label class="monster-main-fields" id="monsterLevel"><p>{{localize "BIO.LEVEL"}}</p><input class="number-input" name="system.bio.level.value" type="number" value="{{this.actor.bio.level.value}}"></input></label></div>
+  <div class="experience-fields monster-experience-fields" >
+    <div><label class="monster-main-fields monster-level"><p>{{localize "BIO.LEVEL"}}</p><input class="number-input" name="system.bio.level.value" type="number" value="{{this.actor.bio.level.value}}"></input></label></div>
     <div><label class="monster-main-fields"><p>{{localize "BIO.INIT"}}</p><input class="number-input" name="system.bio.init.value" type="number" value="{{this.actor.bio.init.value}}"></input></label></div>
   </div>
 </section>

--- a/src/actor/monster/templates/parts/traits.hbs
+++ b/src/actor/monster/templates/parts/traits.hbs
@@ -4,7 +4,7 @@
     <div class="trait-with-answer">
       <h4>
         {{localize "BIO.TYPICAL_TRAITS"}}
-        <input id="typicalTraits" name="system.bio.identity.value" type="text" value="{{this.actor.bio.identity.value}}" />
+        <input class="typical-traits" name="system.bio.identity.value" type="text" value="{{this.actor.bio.identity.value}}" />
       </h4>
     </div>
     <div class="trait-with-answer">

--- a/static/template.json
+++ b/static/template.json
@@ -76,6 +76,12 @@
           }
         }
       },
+      "affinities": {
+        "physical": {
+          "label": "AFFINITIES.PHYSICAL",
+          "value": "-"
+        }
+      },
       "subtype": {
         "type": ""
       }
@@ -127,7 +133,7 @@
         }
       },
       "monster": {
-        "templates": ["baseAttributes", "conditions", "skills", "subtype"],
+        "templates": ["baseAttributes", "affinities", "conditions", "skills", "subtype"],
         "initiative": {
           "max": 14,
           "min": 5,


### PR DESCRIPTION
This updates the UI for monster affinities.  Clicking on individual affinity boxes cycles through the 5 states: Inactive, Vulnerable, Resistant, Immune, Absorbs.

Testing Notes:
- Affinity data persists when closing/reopening monster sheet
- Affinity data persists when restarting the application
- While I do have this data initialized at the Actor level (in case we eventually want to represent them there), there should be no negative affects to old/new character sheets.

Other Notes:
- Unanswered questions:
  - Is this the preferred pattern we want because I don't really see it elsewhere?
  - Where's the best place to document how I initialized/updated the data?